### PR TITLE
pass all topics to onHook, fix event data decoding

### DIFF
--- a/contracts/base-hooks/src/HooksPerpetualAuction.sol
+++ b/contracts/base-hooks/src/HooksPerpetualAuction.sol
@@ -230,6 +230,9 @@ contract HooksPerpetualAuction is Ownable, ReentrancyGuard {
      *      of hook execution success to prevent griefing attacks.
      * @param contractAddr The contract address that triggered the event
      * @param topic0 The event signature that was emitted
+     * @param topic1 The first indexed event parameter (if any)
+     * @param topic2 The second indexed event parameter (if any)
+     * @param topic3 The third indexed event parameter (if any)
      * @param eventData The encoded event data to pass to the hook entrypoint
      * @param originator Address of the user who initiated the transaction causing this event
      * 
@@ -249,6 +252,9 @@ contract HooksPerpetualAuction is Ownable, ReentrancyGuard {
     function executeHook(
         address contractAddr,
         bytes32 topic0,
+        bytes32 topic1,
+        bytes32 topic2,
+        bytes32 topic3,
         bytes calldata eventData,
         address originator
     ) external nonReentrant {
@@ -272,7 +278,7 @@ contract HooksPerpetualAuction is Ownable, ReentrancyGuard {
 
         // Execute hook with fixed gas stipend
         (bool success,) = slot.entrypoint.call{gas: hookGasStipend}(
-            abi.encodeWithSignature("onHook(address,bytes32,bytes)", contractAddr, topic0, eventData)
+            abi.encodeWithSignature("onHook(address,bytes32,bytes32,bytes32,bytes32,bytes)", contractAddr, topic0, topic1, topic2, topic3, eventData)
         );
 
         // Always deduct fee regardless of hook success

--- a/contracts/base-hooks/src/UniswapV2ArbHook.sol
+++ b/contracts/base-hooks/src/UniswapV2ArbHook.sol
@@ -143,23 +143,33 @@ contract UniswapV2ArbHook is Ownable, ReentrancyGuard {
     function onHook(
         address contractAddr,
         bytes32 topic0,
+        bytes32 topic1,
+        bytes32 topic2,
+        bytes32 topic3,
         bytes calldata eventData
     ) external onlySequencer {
         // Decode Uniswap V2 Swap event data
         // Event signature: Swap(address indexed sender, uint256 amount0In, uint256 amount1In, uint256 amount0Out, uint256 amount1Out, address indexed to)
+        // topic0 = keccak256("Swap(address,uint256,uint256,uint256,uint256,address)")
+        // topic1 = indexed sender address
+        // topic2 = indexed to address
+        // topic3 = unused for this event (would be 0x0)
         
-        if (eventData.length < 192) { // 6 * 32 bytes
+        // Extract indexed parameters from topics
+        address sender = address(uint160(uint256(topic1))); // sender from topic1
+        address to = address(uint160(uint256(topic2)));     // to from topic2
+        
+        // eventData only contains the non-indexed parameters: amount0In, amount1In, amount0Out, amount1Out
+        if (eventData.length < 128) { // 4 * 32 bytes for non-indexed params
             revert InvalidEventData();
         }
 
         (
-            address sender,
             uint256 amount0In,
             uint256 amount1In, 
             uint256 amount0Out,
-            uint256 amount1Out,
-            address to
-        ) = abi.decode(eventData, (address, uint256, uint256, uint256, uint256, address));
+            uint256 amount1Out
+        ) = abi.decode(eventData, (uint256, uint256, uint256, uint256));
 
         // Use the contractAddr as the pair address
         _checkArbitrageOpportunity(contractAddr, amount0In, amount1In, amount0Out, amount1Out);


### PR DESCRIPTION
indexed parameters that get included in topics 1 to 3 of an event log are not included in the event.data param - that only contains unindexed params

instead of having the builder merge all topics into the raw data while being positionally aware as well, its easier to just pass all topics and let the consumer handle it